### PR TITLE
Add PageGuard - free all-in-one website health scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Contributions welcome! Please read the [contribution guidelines](#contributing) 
 - [Lighthouse](https://developer.chrome.com/docs/lighthouse/) - Open source, built into Chrome DevTools. Audits performance, accessibility, SEO, and best practices.
 - [CrUX Dashboard](https://developer.chrome.com/docs/crux/) - Real world performance data from Chrome users for millions of websites. Available via BigQuery and the CrUX API.
 - [DebugBear](https://www.debugbear.com) - Monitors Core Web Vitals over time with performance budgets and alerting.
-- [PageGuard](https://pageguard.qiudeqiu.workers.dev) - Free all-in-one website health scanner. Runs Lighthouse audits for performance, SEO, accessibility, and best practices with AI-generated action plans and a CORS-enabled REST API.
+- [PageGuard](https://pageguard.org) - Free all-in-one website health scanner. Runs Lighthouse audits for performance, SEO, accessibility, and best practices with AI-generated action plans and a CORS-enabled REST API.
 
 ## SEO Browser Extensions
 


### PR DESCRIPTION
PageGuard is a free, no-login website health scanner covering Technical SEO, performance (Core Web Vitals), accessibility (WCAG 2.1), and best practices.

- **Live**: https://pageguard.qiudeqiu.workers.dev
- Free, no signup required
- SEO checks + Core Web Vitals + WCAG accessibility
- AI action plans powered by Llama 3.1
- Results in ~30 seconds