### PR TITLE
Add two open-source tools for JavaScript rendering and SEO diagnostics:

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Contributions welcome! Please read the [contribution guidelines](#contributing) 
 - [RalfyIndex](https://ralfyindex.com) - Bulk indexing service. Submits URLs for fast crawling without needing Search Console access. Credit based pricing, no subscription. Averages 89% index rates within 24 hours.
 - [Indexing Insight](https://indexinginsight.com/) - Enterprise index monitoring that tracks up to 1 million pages daily. Shows exactly why pages aren't indexed, with segmentation, filtering, and automated alerts. Breaks past GSC's data limits for large sites. Endorsed by Dan Sharp (Screaming Frog) and used by The Telegraph and Sage.
 - [SEM Samurai](https://www.semsamurai.com/) - Bulk 301-redirect mapping for website migrations. SEM Samurai allows SEOs and developers to accurately match thousands of URLs in minutes to preserve link equity, reduce manual errors and save hours of manual work.
+- [EdgeComet](https://github.com/edgecomet/engine) - Open-source dynamic rendering engine that makes JavaScript content visible to Google, Bing, and AI bots like ChatGPT and Perplexity. Fixes indexing problems on React, Vue, and Angular sites without requiring code changes or SSR migration.
+- [JSBug](https://jsbug.org/) - Free tool for comparing how a webpage looks with and without JavaScript rendering. Shows what search engines and AI bots actually see on JavaScript-heavy sites.
 
 
 ## Rank Tracking


### PR DESCRIPTION
Hi Suganthan!

Adding two open-source tools we built: EdgeComet renders JavaScript for search engines and AI bots so JS-heavy sites get indexed properly, and JSBug lets you compare pages with and without JS to see what bots actually see.